### PR TITLE
Get last status for AfterTestCase when retrying immediately

### DIFF
--- a/com/extension/reportportal/listener/ReportPortalListener.groovy
+++ b/com/extension/reportportal/listener/ReportPortalListener.groovy
@@ -79,7 +79,7 @@ public class ReportPortalListener extends BaseListener implements ExecutionListe
 		this.context.collectIssues()
 		def stepId = this.context.getItem()
 		afterTestClosure = {
-			testItem.finishTestStep(stepId, this.getTestCaseStatus(testInfo))
+			testItem.finishTestStep(stepId, this.getLastTestCaseStatus(testInfo))
 			this.createErrorSteps(stepId)
 			this.createLogSteps(stepId)
 			this.createFullStackTraceLog(testInfo, stepId)
@@ -177,7 +177,11 @@ public class ReportPortalListener extends BaseListener implements ExecutionListe
 		return testName
 	}
 
-	private getTestCaseStatus(InternalTestCaseContext testCase) {
+	private getLastTestCaseStatus(InternalTestCaseContext testCase) {
+		String message = testCase.message;
+		if (testCase.retryIndex > 0 && (message.contains("FAILED") || message.contains("ERROR"))) {
+			return "FAILED"
+		}
 		return testCase.getTestCaseStatus()
 	}
 }


### PR DESCRIPTION
## Issue
When running Test Suite with Retry immediately strategy, if the test case fails, it will set the status to PASS before retrying.
## Root cause
KS reset the Test case status to PASS before retrying
## Solution
Check the retry time and the message to get last status.